### PR TITLE
docs(README): fix description of example usage

### DIFF
--- a/ceteicean-verovio/README.md
+++ b/ceteicean-verovio/README.md
@@ -10,7 +10,7 @@ Live Demo: https://tei-music-sig.github.io/examples/ceteicean-verovio/
 - TEI is rendered by CETEIcean. TEI files are kept separate in the `tei` folder.
 - CETEIcean It prefixes all elements with `tei-` to make them directly styleable with CSS, without interfering with HTML.
 - MEI is rendered by Verovio. MEI files are kept separately in the `mei` folder.
-- Verovio is triggered when a `<notatedMusic>` element in TEI contains `@rend="MEI"` and `@xml:id` corresponds to a filename in `/mei` (without extension).
+- Verovio is triggered when a `<notatedMusic>` element in TEI contains `@rend="MEI"` and `source` corresponds to a filename in `/mei` (with file extension).
 
 ### How to customize
 
@@ -18,7 +18,7 @@ Live Demo: https://tei-music-sig.github.io/examples/ceteicean-verovio/
 - Put your TEI document in the `tei` folder.
 - Modify the stylesheet in `/css/custom.css` using `tei-*`
 - Put your MEI snippets in the `mei` folder.
-- Refer MEI files in the TEI by `<notatedMusic xml:id="[filename]" rend="MEI">`.
+- Refer MEI files in the TEI by `<notatedMusic source="[filename]" rend="MEI">`.
 - Call `index.html` (or just the base directory) in your browser.
 
 If you would like to display more than one TEI file, try [ceteicean-verovio-corpus](../ceteicean-verovio-corpus).

--- a/ceteicean-verovio/README.md
+++ b/ceteicean-verovio/README.md
@@ -16,6 +16,7 @@ Live Demo: https://tei-music-sig.github.io/examples/ceteicean-verovio/
 
 - Download the minimal example.
 - Put your TEI document in the `tei` folder.
+- Rename the reference from CETEICEAN to that TEI file in `index.html` accordingly.
 - Modify the stylesheet in `/css/custom.css` using `tei-*`
 - Put your MEI snippets in the `mei` folder.
 - Refer MEI files in the TEI by `<notatedMusic source="[filename]" rend="MEI">`.

--- a/ceteicean-verovio/README.md
+++ b/ceteicean-verovio/README.md
@@ -10,7 +10,7 @@ Live Demo: https://tei-music-sig.github.io/examples/ceteicean-verovio/
 - TEI is rendered by CETEIcean. TEI files are kept separate in the `tei` folder.
 - CETEIcean It prefixes all elements with `tei-` to make them directly styleable with CSS, without interfering with HTML.
 - MEI is rendered by Verovio. MEI files are kept separately in the `mei` folder.
-- Verovio is triggered when a `<notatedMusic>` element in TEI contains `@rend="MEI"` and `source` corresponds to a filename in `/mei` (with file extension).
+- Verovio is triggered when a `<notatedMusic>` element in TEI contains `@rend="MEI"` and `@source` corresponds to a filename in `/mei` (with file extension).
 
 ### How to customize
 


### PR DESCRIPTION
This PR fixes the description in the README for the ceteicean-verovio workflow according to the actual usage in the provided files in the repo. 

Instead of `@xml:id` the mei files are targeted via `@source` and called with file extension.

It also adds a statement about changing the file name referenced by CETEICEAN in the index.html.